### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,9 @@ name: Linting and style checking
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   markdownlint:
     name: Markdown Lint


### PR DESCRIPTION
Potential fix for [https://github.com/Kohei-Wada/dotfiles/security/code-scanning/6](https://github.com/Kohei-Wada/dotfiles/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow and will set the permissions to `contents: read`, which is sufficient for the linting and style-checking tasks performed in this workflow. This change ensures that the `GITHUB_TOKEN` has only the minimal permissions required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
