### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit-auto-update.yml
+++ b/.github/workflows/pre-commit-auto-update.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 18 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Kohei-Wada/dotfiles/security/code-scanning/4](https://github.com/Kohei-Wada/dotfiles/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow involves committing and pushing changes, it requires `contents: write` permissions. Other permissions should be set to `read` or omitted entirely if not needed.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `update` job. In this case, adding it at the root level is sufficient and ensures clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
