### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,6 +1,8 @@
 name: gitleaks
 
 on: [pull_request, push, workflow_dispatch]
+permissions:
+  contents: read
 
 jobs:
   scan:


### PR DESCRIPTION
Potential fix for [https://github.com/Kohei-Wada/dotfiles/security/code-scanning/2](https://github.com/Kohei-Wada/dotfiles/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only scans the repository for secrets using Gitleaks, it requires minimal permissions. The `contents: read` permission is sufficient for this task, as it allows the workflow to read the repository contents without granting write access.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`scan`) in this workflow. This ensures clarity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
