### PR TITLE
opencode: match per-model context limits to ollama's baked num_ctx

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -13,45 +13,53 @@
                 "baseURL": "http://192.168.0.19:11434/v1"
             },
             "models": {
+                "huihui_ai/Qwen3.6-abliterated:27b": {
+                    "name": "Qwen3.6 27B Abliterated 256K (uncensored)",
+                    "limit": {
+                        "context": 262144,
+                        "output": 8192
+                    }
+                },
                 "qwen3.6:27b": {
                     "name": "Qwen3.6 27B",
                     "limit": {
                         "context": 131072,
-                        "output": 65536
+                        "output": 8192
+                    }
+                },
+                "nemotron-3-nano:30b": {
+                    "name": "Nemotron 3 Nano 30B",
+                    "limit": {
+                        "context": 131072,
+                        "output": 8192
+                    }
+                },
+                "gpt-oss:20b": {
+                    "name": "GPT-OSS 20B",
+                    "limit": {
+                        "context": 131072,
+                        "output": 8192
+                    }
+                },
+                "gemma4:31b-it-qat": {
+                    "name": "Gemma4 31B IT QAT",
+                    "limit": {
+                        "context": 131072,
+                        "output": 8192
                     }
                 },
                 "qwen3:32b": {
                     "name": "Qwen3 32B",
                     "limit": {
                         "context": 40960,
-                        "output": 16384
-                    }
-                },
-                "gpt-oss:20b": {
-                    "name": "GPT-OSS 20B"
-                },
-                "nemotron-3-nano:30b": {
-                    "name": "Nemotron 3 Nano 30B",
-                    "limit": {
-                        "context": 131072,
-                        "output": 65536
-                    }
-                },
-                "gemma4:31b-it-qat": {
-                    "name": "Gemma4 31B IT QAT"
-                },
-                "huihui_ai/Qwen3.6-abliterated:27b": {
-                    "name": "Qwen3.6 27B Abliterated (uncensored)",
-                    "limit": {
-                        "context": 131072,
-                        "output": 65536
+                        "output": 8192
                     }
                 },
                 "qwen3:8b": {
                     "name": "Qwen3 8B",
                     "limit": {
                         "context": 40960,
-                        "output": 16384
+                        "output": 8192
                     }
                 }
             }


### PR DESCRIPTION
## What

Aligns each ollama model's `limit.context` in opencode with the `num_ctx` baked into the model on rtx5090 (see kohei-homelab/nixos-config#100). Adds `limit` to the models that had none (`gpt-oss:20b`, `gemma4:31b-it-qat`) and unifies `output` reservation to 8192.

## Why

opencode talks to ollama over the openai-compatible (`/v1`) path, which **cannot pass `num_ctx`** — so a model's real window is whatever nixos-config baked in. When opencode's `limit.context` exceeds that, opencode keeps sending past the real window, ollama silently truncates the oldest context, and no compaction fires. Verified directly: `qwen3:8b` set to 40960 here loaded at ollama's 32768 default before the num_ctx bake.

## Values (match nixos-config#100)

| model | limit.context |
|---|---|
| huihui_ai/Qwen3.6-abliterated:27b | 262144 |
| qwen3.6:27b / nemotron-3-nano:30b / gpt-oss:20b / gemma4:31b-it-qat | 131072 |
| qwen3:32b / qwen3:8b | 40960 |

Deployed + verified on the box: `ollama ps` shows CONTEXT=262144 at 100% GPU for the 27B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)