### PR TITLE
fix(opencode): point HA MCP at correct SSE endpoint and Tailscale host

### DIFF
--- a/.config/opencode/opencode.json
+++ b/.config/opencode/opencode.json
@@ -106,7 +106,7 @@
         },
         "ha": {
             "type": "remote",
-            "url": "http://homeassistant.local:8123/api/mcp",
+            "url": "http://homeassistant:8123/mcp_server/sse",
             "oauth": false,
             "headers": {
                 "Authorization": "Bearer {env:HA_TOKEN}"


### PR DESCRIPTION
`homeassistant.local` fails mDNS resolution under WSL, and `/api/mcp` is the wrong path (returns 405). Switch to `homeassistant:8123/mcp_server/sse`.

- Host: `homeassistant.local` → `homeassistant` (Tailscale MagicDNS; WSL can't resolve the mDNS name)
- Path: `/api/mcp` → `/mcp_server/sse` (correct HA MCP Server integration endpoint)

Connection verified (endpoint returns 200, token valid). opencode now connects to the HA MCP.